### PR TITLE
Make undelete button hover text lighter

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1209,6 +1209,8 @@ article.edit header .post-close-link {
   font-size: 16px;
   margin-left: 30px;
   text-align: center; }
+.deleted .post-undelete-link:hover {
+  color: #DDD; }
 .deleted .post-undelete-link, .deleted .post-undelete-link:visited {
   background: #222222;
   color: white;

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -308,6 +308,9 @@ article.edit header .post-close-link {
 		text-align: center;
 	}
 	.post-undelete-link {
+		&:hover {
+			color: #DDD;
+		}
 		&,
 		&:visited {
 			background: $gray;


### PR DESCRIPTION
Hover text for undelete currently looks like this.

![current hover](http://cl.ly/image/3a1b2E1u3V1Z/Screen%20Shot%202013-04-18%20at%2011.00.11%20AM.png)

This makes it look like this.

![patch hover](http://cl.ly/image/0m2Q401m420j/Screen%20Shot%202013-04-18%20at%2011.13.47%20AM.png)
