### PR TITLE
Introduces 'capsule_controller_action' action

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -289,6 +289,10 @@ function capsule_controller() {
 // TODO
 
 			break;
+
+			default:
+				do_action( 'capsule_controller_action', $_POST['capsule_action'] );
+				break;
 		}
 	}
 }


### PR DESCRIPTION
Adds a default clause at the end of the capsule_controller() switch and calls
do_action( 'capsule_controller_action', $_POST['capsule_action'] ) to allow
third party plugins to extend the core functionality creating new actions.
