### PR TITLE
Make it a bit nicer at smaller browser sizes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1544,4 +1544,9 @@ pre.static_code {
     display: inline; }
     .edit .post-meta .post-meta-tags li, .content .post-meta .post-meta-tags li {
       display: inline;
-      padding-left: 5px; } }
+      padding-left: 5px; }
+
+  .edit .post-content, .content .post-content {
+    display: inline-block;
+    width: 90%;
+    margin-right: 74px; } }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -960,6 +960,9 @@ body {
   font-family: sans-serif;
   font-size: 13px; }
 
+#wrap {
+  min-width: 520px; }
+
 .container {
   min-height: 100%; }
 
@@ -1517,3 +1520,28 @@ pre.static_code {
     padding-left: 55px; }
     pre.static_code ol li {
       padding-right: 40px; }
+
+@media (max-width: 721px) {
+  .edit .post-date, .content .post-date {
+    width: 100px;
+    height: 80px;
+    position: relative; }
+    .edit .post-date .push-server-meta, .content .post-date .push-server-meta {
+      position: absolute;
+      bottom: 0px;
+      left: 100px; }
+    .edit .post-date > a, .content .post-date > a {
+      position: absolute;
+      bottom: 0px; }
+    .edit .post-date li, .content .post-date li {
+      display: inline-block; }
+    .edit .post-date ul, .content .post-date ul {
+      text-align: left; }
+
+  .edit .post-meta, .content .post-meta {
+    float: none;
+    text-align: right;
+    display: inline; }
+    .edit .post-meta .post-meta-tags li, .content .post-meta .post-meta-tags li {
+      display: inline;
+      padding-left: 5px; } }

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -681,4 +681,10 @@ pre.static_code {
 			padding-left: 5px;
 		}
 	}
+
+	.edit .post-content, .content .post-content {
+		display: inline-block;
+		width: 90%;
+		margin-right: 74px;
+	}
 }

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -6,6 +6,10 @@ body {
 	font-size: 13px;
 }
 
+#wrap {
+	min-width:520px;
+}
+
 .container {
 	min-height: 100%;
 }
@@ -637,6 +641,44 @@ pre.static_code {
 
 		li {
 			padding-right: 40px;
+		}
+	}
+}
+
+@media (max-width: 721px) {
+	.edit .post-date, .content .post-date {
+		width:100px;
+		height:80px;
+		position:relative;
+
+		.push-server-meta {
+			position:absolute;
+			bottom:0px;
+			left: 100px;
+		}
+
+		> a {
+			position:absolute;
+			bottom:0px;
+		}
+
+		li {
+			display:inline-block;
+		}
+
+		ul {
+			text-align:left;
+		}
+	}
+
+	.edit .post-meta, .content .post-meta {
+		float:none;
+		text-align:right;
+		display:inline;
+
+		.post-meta-tags li {
+			display: inline;
+			padding-left: 5px;
 		}
 	}
 }


### PR DESCRIPTION
Basically my use case for this is when using capsule side by side with other applications on the same screen.

As a personal baseline, I wanted it to feel better to use if vertically split screening two applications on a 13" MBA screen, so a browser reduced to half that screen space.

This is just a running start at this, but thought feedback along the way would be good.

Definitely a few edge cases still to address.

This branch takes us from here.

![2013-06-21 at 11 27 46 am](https://f.cloud.github.com/assets/401520/688477/f5c67fae-da97-11e2-82df-001cf34f96d3.png)

To Here

![2013-06-21 at 11 28 46 am](https://f.cloud.github.com/assets/401520/688485/1adf50e0-da98-11e2-8b1a-f6234da288f0.png)
