### PR TITLE
fix typo

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -867,7 +867,7 @@ function capsule_wp_editor_warning()
 	<div class="capsule-editor-warning">
 		<h3><?php esc_html_e('Whoa Cowboy!', 'capsule'); ?></h3>
 		<p>
-			<b><?php esc_html_e('<b>Capsule is designed for front-end editing only.', 'capsule'); ?></b>
+			<b><?php esc_html_e('Capsule is designed for front-end editing only.', 'capsule'); ?></b>
 			<br>
 			<?php
 			esc_html_e(


### PR DESCRIPTION
fixes a leftover html tag in escaped translation